### PR TITLE
[BUG FIX] wallet connection

### DIFF
--- a/src/components/layout/connectWalletModal.tsx
+++ b/src/components/layout/connectWalletModal.tsx
@@ -89,29 +89,40 @@ const ConnectWalletModal = () => {
   };
 
   const handleConnectBraavosWallet = () => {
+    let braavos = false;
     {
       console.log("available", available);
-      available.length > 0
-        ? available.map((connector, id) => {
-            console.log("connect", id, connector.options.id);
-            if (network === "Starknet" && connector.options.id === "braavos") {
-              disconnectEvent(), connect(connector);
-            }
-          })
-        : window.open("https://braavos.app/", "_blank");
+      if (available.length > 0) {
+        available.map((connector, id) => {
+          console.log("connect", id, connector.options.id);
+          if (network === "Starknet" && connector.options.id === "braavos") {
+            braavos = true;
+            disconnectEvent(), connect(connector);
+          }
+        });
+      }
+      if (!braavos) {
+        window.open("https://braavos.app/", "_blank");
+      }
     }
   };
 
   const handleConnectArgentXWallet = () => {
+    let argentX = false;
     {
-      available.length > 0
-        ? available.map((connector, id) => {
-            // // console.log(id);
-            if (network === "Starknet" && connector.options.id === "argentX") {
-              disconnectEvent(), connect(connector);
-            }
-          })
-        : window.open("https://www.argent.xyz/argent-x/", "_blank");
+      console.log("available", available);
+      if (available.length > 0) {
+        available.map((connector, id) => {
+          console.log("connect", id, connector.options.id);
+          if (network === "Starknet" && connector.options.id === "argentX") {
+            argentX = true;
+            disconnectEvent(), connect(connector);
+          }
+        });
+      }
+      if (!argentX) {
+        window.open("https://www.argent.xyz/argent-x/", "_blank");
+      }
     }
   };
   return (


### PR DESCRIPTION
#121 Issue : when the user does not have argentX wallet extension but has braavos wallet extension then the argentX wallet button was unclickable instead of directing the user to https://www.argent.xyz/argent-x/ and vice versa for Braavos wallet

Fix : Added another condition check.

![image](https://github.com/0xHashstack/zkopen-client/assets/86202585/9df56817-8bba-44d6-992e-8ba3b9d17468)

