### PR TITLE
BUG_FIXES

### DIFF
--- a/src/components/modals/borrowModal.tsx
+++ b/src/components/modals/borrowModal.tsx
@@ -2318,6 +2318,7 @@ const BorrowModal = ({
             {(tokenTypeSelected == "rToken" ? rTokenAmount > 0 : true) &&
             (tokenTypeSelected == "Native" ? collateralAmount > 0 : true) &&
             amount > 0 &&
+            rTokenAmount <= walletBalance &&
             inputBorrowAmount <= currentAvailableReserves &&
             inputBorrowAmountUSD <= 4.9999 * inputCollateralAmountUSD ? (
               // (currentCollateralCoin[0]=="r" ? rTokenAmount<=walletBalance :true) &&

--- a/src/components/modals/tradeModal.tsx
+++ b/src/components/modals/tradeModal.tsx
@@ -3163,6 +3163,7 @@ const TradeModal = ({
                   (tokenTypeSelected == "Native" ? collateralAmount > 0 : true) &&
                   inputBorrowAmount <= currentAvailableReserves &&
                   inputBorrowAmount > 0 &&
+                  inputCollateralAmount <= walletBalance &&
                   inputBorrowAmountUSD <= 4.9999 * inputCollateralAmountUSD &&
                   currentDapp != "Select a dapp" &&
                   (currentPool != "Select a pool" ||

--- a/src/components/modals/yourBorrowModal.tsx
+++ b/src/components/modals/yourBorrowModal.tsx
@@ -566,13 +566,13 @@ const YourBorrowModal = ({
         )
         : 0
     );
+    
     // console.log("supply modal status wallet balance",walletBalances[coin?.name]?.statusBalanceOf)
   }, [
     walletBalances[collateralAsset]?.statusBalanceOf,
     collateralAsset,
     currentBorrowId2,
   ]);
-
   useEffect(() => {
     if (loan) {
       setCollateralAsset(
@@ -705,7 +705,10 @@ const YourBorrowModal = ({
   const [radioValue, setRadioValue] = useState("1");
   const [liquiditySplitCoin1, setLiquiditySplitCoin1] = useState("ETH");
   const [liquiditySplitCoin2, setLiquiditySplitCoin2] = useState("USDT");
-
+  useEffect(() => {
+    setCurrentPool("Select a pool");
+    setCurrentPoolCoin("Select a pool");
+  }, [radioValue]);
   const userDeposit = useSelector(selectUserDeposits);
 
   // const [currentBorrowMarketCoin1, setCurrentBorrowMarketCoin1] =


### PR DESCRIPTION
Updated borrow and trade button still active after entering amount greater than wallet balance and reseting the pools in yourborrow modal when the action is switched from Liquidity to Trade.
![image](https://github.com/0xHashstack/v1-client/assets/77379621/73b19d72-da3b-4345-b73f-a731d32f3dcc)
